### PR TITLE
Set TTS playback rate to normal

### DIFF
--- a/api/category/leila/tts.js
+++ b/api/category/leila/tts.js
@@ -31,8 +31,8 @@ export default async function handler(req, res) {
       apiKey: apiKey
     });
 
-    // Use provided speed or default to 0.7 for slower speech suitable for kids (30% slower)
-    const speechSpeed = speed || 0.7;
+    // Use provided speed or default to 1 for normal speech
+    const speechSpeed = speed || 1;
 
     const mp3 = await openai.audio.speech.create({
       model: "tts-1",

--- a/pages/LeilaPage.tsx
+++ b/pages/LeilaPage.tsx
@@ -370,7 +370,7 @@ const LeilaPage: React.FC = () => {
             try {
                 if ('speechSynthesis' in window) {
                     const utterance = new SpeechSynthesisUtterance(text);
-                    utterance.rate = 0.9;
+                    utterance.rate = 1;
                     utterance.pitch = 1.1;
                     utterance.volume = 1;
                     

--- a/pages/SightWordsPage.tsx
+++ b/pages/SightWordsPage.tsx
@@ -56,11 +56,11 @@ const SightWordsPage: React.FC = () => {
     }
 
     try {
-      // Use the existing TTS API endpoint with slower speed
+      // Use the existing TTS API endpoint at normal speed
       const response = await fetch("/category/leila/tts", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ text, speed: 0.7 })
+        body: JSON.stringify({ text, speed: 1 })
       });
       
       if (response.ok) {
@@ -89,11 +89,11 @@ const SightWordsPage: React.FC = () => {
     } catch (error) {
       console.log("Server TTS failed, falling back to Web Speech API:", error);
       
-      // Fallback to Web Speech API with slower speed
+      // Fallback to Web Speech API at normal speed
       if ('speechSynthesis' in window) {
         return new Promise<void>((resolve, reject) => {
           const utterance = new SpeechSynthesisUtterance(text);
-          utterance.rate = 0.7; // 30% slower speech rate for elementary students
+          utterance.rate = 1; // Standard speech rate
           utterance.pitch = 1.1;
           utterance.volume = 1;
           


### PR DESCRIPTION
## Summary
- normalize speech speed in server TTS endpoint
- update TTS rate in Sight Words page
- update fallback TTS rate in Leila page

## Testing
- `npm run build`
